### PR TITLE
Corrected issue with providing options to filepicker.pick

### DIFF
--- a/addon/mixins/ember-filepicker.js
+++ b/addon/mixins/ember-filepicker.js
@@ -40,7 +40,7 @@ export default Ember.Mixin.create({
         }
         else {
           filepicker.pick(
-            options.picker,
+            options,
             Ember.run.bind(this, this.handleSelection),
             Ember.run.bind(this, this.handleError)
           );


### PR DESCRIPTION
Hi,

The most recent commit sends options.picker to the filepicker.pick command when it used to, and should, just send options.  I didn't change the pickAndStore code, though perhaps something needs to change there as well.  As it was it broke submitting the options hash.

Or did you mean to have all the picking options now in a level down in the options hash?  If so then perhaps the README should be updated to show that.

Thanks!

-Max
